### PR TITLE
field initializes on first cell clearing

### DIFF
--- a/src/features/cell/Cell.js
+++ b/src/features/cell/Cell.js
@@ -24,15 +24,6 @@ export default function Cell({props}){
     let minefield = useSelector(selectMineField)
 
     useEffect(() => {
-        dispatch(updateAdjacentCells(props))
-        dispatch(updateCell({
-            row: props.row, 
-            col: props.col, 
-            updates:[{key: 'isCleared', val: false}, {key: 'isFlagged', val: false}]
-        }))
-    }, [])
-
-    useEffect(() => {
         setAdjMineCount(minefield[props.row][props.col].adjacentCells.filter((cell) => cell.hasMine).length)
     }, [minefield])
 

--- a/src/features/minefield/Minefield.js
+++ b/src/features/minefield/Minefield.js
@@ -11,7 +11,7 @@ export default function Minefield(){
     const dispatch = useDispatch();
     const minefield = useSelector(selectMineField);
     useEffect(() => {
-        dispatch(generateMineField({count: 10, rows: 9, columns: 9}))
+        dispatch(generateMineField())
     }, [dispatch])
     return ( 
         <>

--- a/src/features/minefield/minefieldSlice.spec.js
+++ b/src/features/minefield/minefieldSlice.spec.js
@@ -20,6 +20,10 @@ const mineFieldSize = (minefield) => {
     return [minefield.length, minefield[0].length]
 }
 
+Array.prototype.copyMinefield = function() {
+    return [...this.map((row) => [...row.map((cell) => {return {...cell}})])]
+}
+
 describe('minefield reducer', () => {
     const initialState = {
         minefield: []
@@ -29,18 +33,19 @@ describe('minefield reducer', () => {
             minefield: []
         })
     });
-    it('should handle generate minefield', () => {
+    it('should generate a minefield with 99 mines when args are empty', () => {
         const actual = minefieldReducer(initialState, generateMineField());
         const actualMineCount = countMines(actual.minefield)
-        expect(actualMineCount).toEqual(99)
+        expect(actualMineCount).toEqual(0)
     })
-    it('should handle update minefield', () => {
-        const actual = minefieldReducer(initialState, generateMineField());
+    it('should generate a minefield with the correct number of mines when count is not empty and a valid cell is clicked', () => {
+        const actual = minefieldReducer(initialState, 
+            generateMineField({count: 99, rows: 16, columns: 30, cell: {row:0, col: 0}}));
         const actualMineCount = countMines(actual.minefield)
         expect(actualMineCount).toEqual(99)
     })
     it('should update cell', () => {
-        const newMinefield = generateMines({count: 99, rows: 16, columns: 30})
+        const newMinefield = generateMines({count: 99, rows: 16, columns: 30, cell: {row: 0, col: 5}})
         let expectedCell = {...newMinefield[0][0]}
         expectedCell.val = expectedCell.val === 1 ? 0 : 1
         expectedCell.isFlagged = !expectedCell.isFlagged
@@ -69,29 +74,29 @@ describe('minefield reducer', () => {
     it('should update minefield cell with adjacent cells', () => {
         const mineField = [
             [{id: '0_0', hasMine: false, row: 0, col: 0, isFlagged: false, isCleared: false, adjacentCells: []},
-            {id: '0_1', hasMine: true,  row: 0, col: 1, isFlagged: false, isCleared: false, adjacentCells: []},
-            {id: '0_2', hasMine: false, row: 0, col: 2, isFlagged: false, isCleared: false, adjacentCells: []},
-            {id: '0_3', hasMine: true,  row: 0, col: 3, isFlagged: false, isCleared: false, adjacentCells: []},
-            {id: '0_4', hasMine: false, row: 0, col: 4, isFlagged: false, isCleared: false, adjacentCells: []},
-            {id: '0_5', hasMine: true,  row: 0, col: 5, isFlagged: false, isCleared: false, adjacentCells: []},],
+             {id: '0_1', hasMine: true,  row: 0, col: 1, isFlagged: false, isCleared: false, adjacentCells: []},
+             {id: '0_2', hasMine: false, row: 0, col: 2, isFlagged: false, isCleared: false, adjacentCells: []},
+             {id: '0_3', hasMine: true,  row: 0, col: 3, isFlagged: false, isCleared: false, adjacentCells: []},
+             {id: '0_4', hasMine: false, row: 0, col: 4, isFlagged: false, isCleared: false, adjacentCells: []},
+             {id: '0_5', hasMine: true,  row: 0, col: 5, isFlagged: false, isCleared: false, adjacentCells: []},],
             [{id: '1_0', hasMine: false, row: 1, col: 0, isFlagged: false, isCleared: false, adjacentCells: []},
-            {id: '1_1', hasMine: true,  row: 1, col: 1, isFlagged: false, isCleared: false, adjacentCells: []},
-            {id: '1_2', hasMine: false, row: 1, col: 2, isFlagged: false, isCleared: false, adjacentCells: []},
-            {id: '1_3', hasMine: true,  row: 1, col: 3, isFlagged: false, isCleared: false, adjacentCells: []},
-            {id: '1_4', hasMine: false, row: 1, col: 4, isFlagged: false, isCleared: false, adjacentCells: []},
-            {id: '1_5', hasMine: true,  row: 1, col: 5, isFlagged: false, isCleared: false, adjacentCells: []},],
+             {id: '1_1', hasMine: true,  row: 1, col: 1, isFlagged: false, isCleared: false, adjacentCells: []},
+             {id: '1_2', hasMine: false, row: 1, col: 2, isFlagged: false, isCleared: false, adjacentCells: []},
+             {id: '1_3', hasMine: true,  row: 1, col: 3, isFlagged: false, isCleared: false, adjacentCells: []},
+             {id: '1_4', hasMine: false, row: 1, col: 4, isFlagged: false, isCleared: false, adjacentCells: []},
+             {id: '1_5', hasMine: true,  row: 1, col: 5, isFlagged: false, isCleared: false, adjacentCells: []},],
             [{id: '2_0', hasMine: false, row: 2, col: 0, isFlagged: false, isCleared: false, adjacentCells: []},
-            {id: '2_1', hasMine: true,  row: 2, col: 1, isFlagged: false, isCleared: false, adjacentCells: []},
-            {id: '2_2', hasMine: false, row: 2, col: 2, isFlagged: false, isCleared: false, adjacentCells: []},
-            {id: '2_3', hasMine: true,  row: 2, col: 3, isFlagged: false, isCleared: false, adjacentCells: []},
-            {id: '2_4', hasMine: false, row: 2, col: 4, isFlagged: false, isCleared: false, adjacentCells: []},
-            {id: '2_5', hasMine: true,  row: 2, col: 5, isFlagged: false, isCleared: false, adjacentCells: []},],
+             {id: '2_1', hasMine: true,  row: 2, col: 1, isFlagged: false, isCleared: false, adjacentCells: []},
+             {id: '2_2', hasMine: false, row: 2, col: 2, isFlagged: false, isCleared: false, adjacentCells: []},
+             {id: '2_3', hasMine: true,  row: 2, col: 3, isFlagged: false, isCleared: false, adjacentCells: []},
+             {id: '2_4', hasMine: false, row: 2, col: 4, isFlagged: false, isCleared: false, adjacentCells: []},
+             {id: '2_5', hasMine: true,  row: 2, col: 5, isFlagged: false, isCleared: false, adjacentCells: []},],
             [{id: '3_0', hasMine: false, row: 2, col: 0, isFlagged: false, isCleared: false, adjacentCells: []},
-            {id: '3_1', hasMine: true,  row: 3, col: 1, isFlagged: false, isCleared: false, adjacentCells: []},
-            {id: '3_2', hasMine: false, row: 3, col: 2, isFlagged: false, isCleared: false, adjacentCells: []},
-            {id: '3_3', hasMine: true,  row: 3, col: 3, isFlagged: false, isCleared: false, adjacentCells: []},
-            {id: '3_4', hasMine: false, row: 3, col: 4, isFlagged: false, isCleared: false, adjacentCells: []},
-            {id: '3_5', hasMine: true,  row: 3, col: 5, isFlagged: false, isCleared: false, adjacentCells: []},]
+             {id: '3_1', hasMine: true,  row: 3, col: 1, isFlagged: false, isCleared: false, adjacentCells: []},
+             {id: '3_2', hasMine: false, row: 3, col: 2, isFlagged: false, isCleared: false, adjacentCells: []},
+             {id: '3_3', hasMine: true,  row: 3, col: 3, isFlagged: false, isCleared: false, adjacentCells: []},
+             {id: '3_4', hasMine: false, row: 3, col: 4, isFlagged: false, isCleared: false, adjacentCells: []},
+             {id: '3_5', hasMine: true,  row: 3, col: 5, isFlagged: false, isCleared: false, adjacentCells: []},]
         ]
         let row = 2, col = 2
         let cell = {...mineField[row][col]}
@@ -112,7 +117,7 @@ describe('minefield reducer', () => {
     })
     it('should clear cells surrounding a cell with no adjacent mines', () => {
         const mineField = [
-            [{id: '0_0', hasMine: false, row: 0, col: 0, isFlagged: false, isCleared: false, adjacentCells: []},
+            [{id: '0_0', hasMine: true,  row: 0, col: 0, isFlagged: false, isCleared: false, adjacentCells: []},
              {id: '0_1', hasMine: false, row: 0, col: 1, isFlagged: false, isCleared: false, adjacentCells: []},
              {id: '0_2', hasMine: false, row: 0, col: 2, isFlagged: false, isCleared: false, adjacentCells: []},
              {id: '0_3', hasMine: false, row: 0, col: 3, isFlagged: false, isCleared: false, adjacentCells: []},],
@@ -124,39 +129,36 @@ describe('minefield reducer', () => {
              {id: '2_1', hasMine: false, row: 2, col: 1, isFlagged: false, isCleared: false, adjacentCells: []},
              {id: '2_2', hasMine: false, row: 2, col: 2, isFlagged: false, isCleared: false, adjacentCells: []},
              {id: '2_3', hasMine: false, row: 2, col: 3, isFlagged: false, isCleared: false, adjacentCells: []},],
-            [{id: '3_0', hasMine: false, row: 3, col: 0, isFlagged: false, isCleared: false, adjacentCells: []},
+            [{id: '3_0', hasMine: false, row: 3, col: 0, isFlagged: false, isCleared: true,  adjacentCells: []},
              {id: '3_1', hasMine: false, row: 3, col: 1, isFlagged: false, isCleared: false, adjacentCells: []},
              {id: '3_2', hasMine: false, row: 3, col: 2, isFlagged: false, isCleared: false, adjacentCells: []},
              {id: '3_3', hasMine: false, row: 3, col: 3, isFlagged: false, isCleared: false, adjacentCells: []},]
         ]
-        let updatedMinefield = Array(4).fill().map(() => Array(4).fill());
-        let expectedMinefield = Array(4).fill().map(() => Array(4).fill());
+        let updatedMinefield = mineField.copyMinefield()
         updatedMinefield.forEach((row, rIndex) => {
             row.forEach((cell, cIndex) => {
                 const adjCells = adjacentCells({row: rIndex, col: cIndex}, mineField)
                 let thisCell = {...mineField[rIndex][cIndex]}
                 thisCell.adjacentCells = adjCells
                 updatedMinefield[thisCell.row][thisCell.col] = {...thisCell}
-                expectedMinefield[thisCell.row][thisCell.col] = {...thisCell}
             })
         })
-        const state = {minefield: updatedMinefield}
         let selectedCell = updatedMinefield[1][2]
+        let expectedMinefield = updatedMinefield.copyMinefield()
         expectedMinefield.forEach((row) => {
             row.forEach((cell) => {
-                if((cell.row !== 2 || cell.col !== 0) && (cell.row !== 3 || cell.col !== 0)){
+                if(cell.col !== 0){
                     cell.isCleared = true
-                } else {
-                    cell.isCleared = false
                 }
             }) 
         })
+        const state = {minefield: updatedMinefield}
         const actualState = minefieldReducer(state, clearCell(selectedCell))
         expect(actualState.minefield).toEqual(expectedMinefield)
     })
     it('should show all mines if a cell with a mine is cleared', () => {
         const mineField = [
-            [{id: '0_0', hasMine: false, row: 0, col: 0, isFlagged: false, isCleared: false, adjacentCells: []},
+            [{id: '0_0', hasMine: false, row: 0, col: 0, isFlagged: false, isCleared: true, adjacentCells: []},
              {id: '0_1', hasMine: true,  row: 0, col: 1, isFlagged: false, isCleared: false, adjacentCells: []},
              {id: '0_2', hasMine: false, row: 0, col: 2, isFlagged: false, isCleared: false, adjacentCells: []},
              {id: '0_3', hasMine: false, row: 0, col: 3, isFlagged: false, isCleared: false, adjacentCells: []},],
@@ -173,23 +175,23 @@ describe('minefield reducer', () => {
              {id: '3_2', hasMine: false, row: 3, col: 2, isFlagged: false, isCleared: false, adjacentCells: []},
              {id: '3_3', hasMine: false, row: 3, col: 3, isFlagged: false, isCleared: false, adjacentCells: []},]
         ]
-        let updatedMinefield = Array(4).fill().map(() => Array(4).fill());
-        let expectedMinefield = Array(4).fill().map(() => Array(4).fill());
+        let updatedMinefield = mineField.copyMinefield()
         updatedMinefield.forEach((row, rIndex) => {
             row.forEach((cell, cIndex) => {
                 const adjCells = adjacentCells({row: rIndex, col: cIndex}, mineField)
                 let thisCell = {...mineField[rIndex][cIndex]}
                 thisCell.adjacentCells = adjCells
                 updatedMinefield[thisCell.row][thisCell.col] = {...thisCell}
-                expectedMinefield[thisCell.row][thisCell.col] = {...thisCell}
             })
         })
-        const state = {minefield: updatedMinefield}
         let selectedCell = updatedMinefield[0][1]
+        let expectedMinefield = updatedMinefield.copyMinefield()
         expectedMinefield[0][1].isCleared = true
         expectedMinefield[2][0].isCleared = true
         expectedMinefield[2][1].isCleared = true
         expectedMinefield[3][0].isCleared = true
+
+        const state = {minefield: updatedMinefield}
         const actualState = minefieldReducer(state, clearCell(selectedCell))
         expect(actualState.minefield).toEqual(expectedMinefield)
     })
@@ -212,112 +214,134 @@ describe('minefield reducer', () => {
              {id: '3_2', hasMine: false, row: 3, col: 2, isFlagged: false, isCleared: true, adjacentCells: []},
              {id: '3_3', hasMine: false, row: 3, col: 3, isFlagged: false, isCleared: true, adjacentCells: []},]
         ]
-        let updatedMinefield = Array(4).fill().map(() => Array(4).fill());
-        let expectedMinefield = Array(4).fill().map(() => Array(4).fill());
+        let updatedMinefield = mineField.copyMinefield()
         updatedMinefield.forEach((row, rIndex) => {
             row.forEach((cell, cIndex) => {
                 const adjCells = adjacentCells({row: rIndex, col: cIndex}, mineField)
                 let thisCell = {...mineField[rIndex][cIndex]}
                 thisCell.adjacentCells = adjCells
                 updatedMinefield[thisCell.row][thisCell.col] = {...thisCell}
-                expectedMinefield[thisCell.row][thisCell.col] = {...thisCell}
             })
         })
-        const state = {minefield: updatedMinefield}
         let selectedCell = updatedMinefield[0][0]
-        const actualState = minefieldReducer(state, clearCell(selectedCell))
+        let expectedMinefield = updatedMinefield.copyMinefield()
         expectedMinefield.forEach((row) => row.forEach((cell) => {
             cell.isCleared = !cell.hasMine
             cell.isFlagged = cell.hasMine
             return cell
         }))
+        const state = {minefield: updatedMinefield}
+        const actualState = minefieldReducer(state, clearCell(selectedCell))
         expect(actualState.minefield).toEqual(expectedMinefield)
     })
 })
 
 describe('helper functions', () => {
     let newMinefield = generateMines()
-    it('by default, generateMines should generate a 16x30 array', () => {
+    it('by default, generateMines should generate a 16x30 array with 0 mines', () => {
         const actualSize = mineFieldSize(newMinefield)
-        expect([16,30]).toEqual(actualSize)
-    })
-    it('by default, generateMines should generate 99 mines', () => {
         const actualMineCount = countMines(newMinefield)
-        expect(99).toEqual(actualMineCount)
+        expect([16,30]).toEqual(actualSize)
+        expect(0).toEqual(actualMineCount)
     })
-    let fullArgs = {count: 10, rows: 5, columns: 10}
-    it('given a full set of argments, generateMines should generate a 5x10 array', () => {
+    let fullArgs = {count: 10, rows: 5, columns: 10, cell: {row:0, col: 0}}
+    it('given a full set of argments, generateMines should generate a 5x10 array and 10 mines', () => {
         newMinefield = generateMines(fullArgs)
         const actualSize = mineFieldSize(newMinefield)
-        expect([fullArgs.rows, fullArgs.columns]).toEqual(actualSize)
-    })
-    it('given a full set of argments, generateMines should generate 10 mines', () => {
-        newMinefield = generateMines(fullArgs)
         const actualMineCount = countMines(newMinefield)
         expect(fullArgs.count).toEqual(actualMineCount)
+        expect([fullArgs.rows, fullArgs.columns]).toEqual(actualSize)
     })
-    it('cellUpdater should update all fields', () => {
-        let expectedCell = {...newMinefield[0][0]}
-        expectedCell.val = expectedCell.val === 1 ? 0 : 1
-        expectedCell.isFlagged = !expectedCell.isFlagged
-        expectedCell.isCleared = !expectedCell.isCleared
-        expectedCell.adjacentCells = [
-            {row: 0, col: 1, val: newMinefield[0][1].val},
-            {row: 1, col: 0, val: newMinefield[1][0].val},
-            {row: 1, col: 1, val: newMinefield[1][1].val},
+    it('when clicking the first cell in a field with only 1 empty space, generateMines should return the clicked cell as the only cleared cell', () => {
+        let actualField = generateMines({count: 3, rows: 2, columns: 2, cell: {row: 0, col: 0}})
+        let expectedField = actualField.copyMinefield()
+        expectedField[0][0].hasMine = false
+        expectedField[0][1].hasMine = true
+        expectedField[1][0].hasMine = true
+        expectedField[1][1].hasMine = true
+        expect(expectedField).toEqual(actualField)
+    })
+    it('when clicking the first cell in a field with only 2 empty cells, generateMines should return the clicked cell and 1 adjacent cell as the only cleared cells', () => {
+        let actualField = generateMines({count: 2, rows: 2, columns: 2, cell: {row: 0, col: 0}})
+        let emptyCount = adjacentCells({row: 0, col: 0}, actualField).filter((c) => !c.hasMine).length
+        expect(1).toEqual(emptyCount)
+    })
+    it('when clicking the first cell in a field with only 3 empty cells, generateMines should return the clicked cell and 2 adjacent cells as the only cleared cells', () => {
+        let actualField = generateMines({count: 1, rows: 2, columns: 2, cell: {row: 0, col: 0}})
+        let emptyCount = adjacentCells({row: 0, col: 0}, actualField).filter((c) => !c.hasMine).length
+        expect(2).toEqual(emptyCount)
+    })
+    it('when clicking the a cell in a field with > 8 empty cells, generateMines should return the clicked cell and all adjacent cells as cleared cells', () => {
+        let actualField = generateMines({count: 3, rows: 3, columns: 4, cell: {row: 1, col: 1}})
+        let emptyCount = adjacentCells({row: 1, col: 1}, actualField)
+        emptyCount.push(actualField[1][1])
+        let filteredEmptyCount = emptyCount.filter((c) => !c.hasMine).length
+        expect(filteredEmptyCount).toEqual(9)
+    })
+    it('cellUpdater should update start a new game when the cell clicked is the first cleared cell', () => {
+        const clickedCell = {row: 4, col: 6}
+        let cellClicked = {...newMinefield[clickedCell.row][clickedCell.col]}
+        cellClicked.hasMine = false
+        cellClicked.isFlagged = false
+        cellClicked.isCleared = true
+        // There may be more adjacent cells to these that are also false, but this should be the minimum
+        cellClicked.adjacentCells = [
+            {row: clickedCell.row - 1, col: clickedCell.col - 1, hasMine: false},
+            {row: clickedCell.row - 1, col: clickedCell.col,     hasMine: false},
+            {row: clickedCell.row - 1, col: clickedCell.col + 1, hasMine: false},
+            {row: clickedCell.row,     col: clickedCell.col - 1, hasMine: false},
+            {row: clickedCell.row,     col: clickedCell.col + 1, hasMine: false},
+            {row: clickedCell.row + 1, col: clickedCell.col - 1, hasMine: false},
+            {row: clickedCell.row + 1, col: clickedCell.col,     hasMine: false},
+            {row: clickedCell.row + 1, col: clickedCell.col + 1, hasMine: false},
         ]
-        const updateDetails = {
-            row: 0, col: 0, updates:[
-                {key: 'val', val: expectedCell.val},
-                {key: 'isFlagged', val: expectedCell.isFlagged},
-                {key: 'isCleared', val: expectedCell.isCleared},
-                {key: 'adjacentCells', val: expectedCell.adjacentCells},
-            ]
-        }
-        const updatedMinefield = cellUpdater(updateDetails, newMinefield)
-        const actualCell = {...updatedMinefield[0][0]}
-        expect(expectedCell.val).toEqual(actualCell.val)
-        expect(expectedCell.isFlagged).toEqual(actualCell.isFlagged)
-        expect(expectedCell.isCleared).toEqual(actualCell.isCleared)
-        expect(expectedCell.adjacentCells).toEqual(actualCell.adjacentCells)
-        
+        const updatedMinefield = cellClearer(cellClicked, newMinefield)
+        const mineCount = countMines(updatedMinefield)
+        const fieldSize = mineFieldSize(updatedMinefield)
+        expect(mineCount).toEqual(99)
+        expect(fieldSize).toEqual([16, 30])
+        expect(cellClicked).toEqual(updatedMinefield[clickedCell.row][clickedCell.col])
+        cellClicked.adjacentCells.forEach((cell) => {
+            expect(cell.hasMine).toEqual(updatedMinefield[cell.row][cell.col].hasMine)
+            expect(updatedMinefield[cell.row][cell.col].isCleared).toBeTruthy()
+        })
     })
-    /*
-        0   1   2
-        3   C   4
-        5   6   7
+    // /*
+    //     0   1   2
+    //     3   C   5
+    //     6   7   8
 
-        #'s are offest indeces
-        C is the cell location, {row, col}
-        If the index
-            is b/n 0-2, than adjacent row is 1 row up.  So subtract 1 from cell.row
-            is b/n 3/4, than adjacent row match cell.row.  So return cell.row
-            is b/n 5-7, than adjacent row is 1 row down.  So add 1 to cell.row
-        if the index
-            is in [0,3,5], than the adjacent column should be to the left.  So subtract 1 from the cell.col
-            is in [1,6], than the adjacent column sould match cell.col.  So return cell.col
-            is in [2,2,7], than the adjacent column should be to the right.  So add 1 to cell.col
+    //     #'s are offest indeces
+    //     C is the cell location, {row, col}
+    //     If the index
+    //         is b/n 0-2, than adjacent row is 1 row up.  So subtract 1 from cell.row
+    //         is b/n 3-5, than adjacent row match cell.row.  So return cell.row
+    //         is b/n 6-8, than adjacent row is 1 row down.  So add 1 to cell.row
+    //     if the index
+    //         is in [0,3,6], than the adjacent column should be to the left.  So subtract 1 from the cell.col
+    //         is in [1,7], than the adjacent column sould match cell.col.  So return cell.col
+    //         is in [2,5,8], than the adjacent column should be to the right.  So add 1 to cell.col
         
-        It is ok if a cell has a -1 index for either the row or column, that will get filterd out of the final adject cells array.
-    */
+    //     It is ok if a cell has a -1 index for either the row or column, that will get filterd out of the final adject cells array.
+    // */
     it('given a cell location of {0,0} and offset index, getOffsetByIndex should return a {row, col} with some (-1) index values', () => {
         const cell = {row: 0, col: 0}
         const actualOffsetCoordinateAt0 = getOffsetCoordinate(cell, 0)
         const actualOffsetCoordinateAt1 = getOffsetCoordinate(cell, 1)
         const actualOffsetCoordinateAt2 = getOffsetCoordinate(cell, 2)
         const actualOffsetCoordinateAt3 = getOffsetCoordinate(cell, 3)
-        const actualOffsetCoordinateAt4 = getOffsetCoordinate(cell, 4)
         const actualOffsetCoordinateAt5 = getOffsetCoordinate(cell, 5)
         const actualOffsetCoordinateAt6 = getOffsetCoordinate(cell, 6)
         const actualOffsetCoordinateAt7 = getOffsetCoordinate(cell, 7)
+        const actualOffsetCoordinateAt8 = getOffsetCoordinate(cell, 8)
         expect(actualOffsetCoordinateAt0).toEqual({row: -1, col: -1})
         expect(actualOffsetCoordinateAt1).toEqual({row: -1, col:  0})
         expect(actualOffsetCoordinateAt2).toEqual({row: -1, col:  1})
         expect(actualOffsetCoordinateAt3).toEqual({row:  0, col: -1})
-        expect(actualOffsetCoordinateAt4).toEqual({row:  0, col:  1})
-        expect(actualOffsetCoordinateAt5).toEqual({row:  1, col: -1})
-        expect(actualOffsetCoordinateAt6).toEqual({row:  1, col:  0})
-        expect(actualOffsetCoordinateAt7).toEqual({row:  1, col:  1})
+        expect(actualOffsetCoordinateAt5).toEqual({row:  0, col:  1})
+        expect(actualOffsetCoordinateAt6).toEqual({row:  1, col: -1})
+        expect(actualOffsetCoordinateAt7).toEqual({row:  1, col:  0})
+        expect(actualOffsetCoordinateAt8).toEqual({row:  1, col:  1})
     })
     it('given a cell location of {3,4} and offset index, getOffsetByIndex should return a {row, col}', () => {
         const cell = {row: 3, col: 4}
@@ -325,18 +349,18 @@ describe('helper functions', () => {
         const actualOffsetCoordinateAt1 = getOffsetCoordinate(cell, 1)
         const actualOffsetCoordinateAt2 = getOffsetCoordinate(cell, 2)
         const actualOffsetCoordinateAt3 = getOffsetCoordinate(cell, 3)
-        const actualOffsetCoordinateAt4 = getOffsetCoordinate(cell, 4)
         const actualOffsetCoordinateAt5 = getOffsetCoordinate(cell, 5)
         const actualOffsetCoordinateAt6 = getOffsetCoordinate(cell, 6)
         const actualOffsetCoordinateAt7 = getOffsetCoordinate(cell, 7)
+        const actualOffsetCoordinateAt8 = getOffsetCoordinate(cell, 8)
         expect(actualOffsetCoordinateAt0).toEqual({row: 2, col: 3})
-        expect(actualOffsetCoordinateAt1).toEqual({row: 2, col:  4})
-        expect(actualOffsetCoordinateAt2).toEqual({row: 2, col:  5})
-        expect(actualOffsetCoordinateAt3).toEqual({row:  3, col: 3})
-        expect(actualOffsetCoordinateAt4).toEqual({row:  3, col:  5})
-        expect(actualOffsetCoordinateAt5).toEqual({row:  4, col: 3})
-        expect(actualOffsetCoordinateAt6).toEqual({row:  4, col:  4})
-        expect(actualOffsetCoordinateAt7).toEqual({row:  4, col:  5})
+        expect(actualOffsetCoordinateAt1).toEqual({row: 2, col: 4})
+        expect(actualOffsetCoordinateAt2).toEqual({row: 2, col: 5})
+        expect(actualOffsetCoordinateAt3).toEqual({row: 3, col: 3})
+        expect(actualOffsetCoordinateAt5).toEqual({row: 3, col: 5})
+        expect(actualOffsetCoordinateAt6).toEqual({row: 4, col: 3})
+        expect(actualOffsetCoordinateAt7).toEqual({row: 4, col: 4})
+        expect(actualOffsetCoordinateAt8).toEqual({row: 4, col: 5})
     })
     it('given a cell location, {row, col}, it should return the cell value or null if outside the minefield array', () => {
         const mineField = generateMines()
@@ -400,7 +424,7 @@ describe('helper functions', () => {
     })
     it('should return a minefield with the adjacent cells cleared when adjacent mine count is 0', () => {
         const mineField = [
-            [{id: '0_0', hasMine: false, row: 0, col: 0, isFlagged: false, isCleared: false, adjacentCells: []},
+            [{id: '0_0', hasMine: true,  row: 0, col: 0, isFlagged: false, isCleared: false, adjacentCells: []},
              {id: '0_1', hasMine: false, row: 0, col: 1, isFlagged: false, isCleared: false, adjacentCells: []},
              {id: '0_2', hasMine: false, row: 0, col: 2, isFlagged: false, isCleared: false, adjacentCells: []},
              {id: '0_3', hasMine: false, row: 0, col: 3, isFlagged: false, isCleared: false, adjacentCells: []},],
@@ -412,38 +436,36 @@ describe('helper functions', () => {
              {id: '2_1', hasMine: false, row: 2, col: 1, isFlagged: false, isCleared: false, adjacentCells: []},
              {id: '2_2', hasMine: false, row: 2, col: 2, isFlagged: false, isCleared: false, adjacentCells: []},
              {id: '2_3', hasMine: false, row: 2, col: 3, isFlagged: false, isCleared: false, adjacentCells: []},],
-            [{id: '3_0', hasMine: false, row: 3, col: 0, isFlagged: false, isCleared: false, adjacentCells: []},
+            [{id: '3_0', hasMine: false, row: 3, col: 0, isFlagged: false, isCleared: true,  adjacentCells: []},
              {id: '3_1', hasMine: false, row: 3, col: 1, isFlagged: false, isCleared: false, adjacentCells: []},
              {id: '3_2', hasMine: false, row: 3, col: 2, isFlagged: false, isCleared: false, adjacentCells: []},
              {id: '3_3', hasMine: false, row: 3, col: 3, isFlagged: false, isCleared: false, adjacentCells: []},]
         ]
-        let updatedMinefield = Array(4).fill().map(() => Array(4).fill());
-        let expectedMinefield = Array(4).fill().map(() => Array(4).fill());
+        let updatedMinefield = mineField.copyMinefield()
         updatedMinefield.forEach((row, rIndex) => {
             row.forEach((cell, cIndex) => {
                 const adjCells = adjacentCells({row: rIndex, col: cIndex}, mineField)
                 let thisCell = {...mineField[rIndex][cIndex]}
                 thisCell.adjacentCells = adjCells
                 updatedMinefield[thisCell.row][thisCell.col] = {...thisCell}
-                expectedMinefield[thisCell.row][thisCell.col] = {...thisCell}
             })
         })
         let selectedCell = updatedMinefield[1][2]
-        const actualMinefield = cellClearer(selectedCell, [...updatedMinefield])
+
+        let expectedMinefield = updatedMinefield.copyMinefield()
         expectedMinefield.forEach((row) => {
             row.forEach((cell) => {
-                if((cell.row !== 2 || cell.col !== 0) && (cell.row !== 3 || cell.col !== 0)){
+                if(cell.col !== 0){
                     cell.isCleared = true
-                } else {
-                    cell.isCleared = false
                 }
             }) 
         })
+        const actualMinefield = cellClearer(selectedCell, [...updatedMinefield])
         expect(actualMinefield).toEqual(expectedMinefield)
     })
     it('should show all mines if a cell with a mine is cleared', () => {
         const mineField = [
-            [{id: '0_0', hasMine: false, row: 0, col: 0, isFlagged: false, isCleared: false, adjacentCells: []},
+            [{id: '0_0', hasMine: false, row: 0, col: 0, isFlagged: false, isCleared: true, adjacentCells: []},
              {id: '0_1', hasMine: true,  row: 0, col: 1, isFlagged: false, isCleared: false, adjacentCells: []},
              {id: '0_2', hasMine: false, row: 0, col: 2, isFlagged: false, isCleared: false, adjacentCells: []},
              {id: '0_3', hasMine: false, row: 0, col: 3, isFlagged: false, isCleared: false, adjacentCells: []},],
@@ -460,23 +482,14 @@ describe('helper functions', () => {
              {id: '3_2', hasMine: false, row: 3, col: 2, isFlagged: false, isCleared: false, adjacentCells: []},
              {id: '3_3', hasMine: false, row: 3, col: 3, isFlagged: false, isCleared: false, adjacentCells: []},]
         ]
-        let updatedMinefield = Array(4).fill().map(() => Array(4).fill());
-        let expectedMinefield = Array(4).fill().map(() => Array(4).fill());
-        updatedMinefield.forEach((row, rIndex) => {
-            row.forEach((cell, cIndex) => {
-                const adjCells = adjacentCells({row: rIndex, col: cIndex}, mineField)
-                let thisCell = {...mineField[rIndex][cIndex]}
-                thisCell.adjacentCells = adjCells
-                updatedMinefield[thisCell.row][thisCell.col] = {...thisCell}
-                expectedMinefield[thisCell.row][thisCell.col] = {...thisCell}
-            })
-        })
+        let updatedMinefield = mineField.copyMinefield()
+        let expectedMinefield = mineField.copyMinefield()
         let selectedCell = updatedMinefield[0][1]
-        const actualMinefield = cellClearer(selectedCell, [...updatedMinefield])
         expectedMinefield[0][1].isCleared = true
         expectedMinefield[2][0].isCleared = true
         expectedMinefield[2][1].isCleared = true
         expectedMinefield[3][0].isCleared = true
+        const actualMinefield = cellClearer(selectedCell, [...updatedMinefield])
         expect(actualMinefield).toEqual(expectedMinefield)
     })
     it('should show all mines if a cell with a mine is cleared', () => {
@@ -498,24 +511,15 @@ describe('helper functions', () => {
              {id: '3_2', hasMine: false, row: 3, col: 2, isFlagged: false, isCleared: true, adjacentCells: []},
              {id: '3_3', hasMine: false, row: 3, col: 3, isFlagged: false, isCleared: true, adjacentCells: []},]
         ]
-        let updatedMinefield = Array(4).fill().map(() => Array(4).fill());
-        let expectedMinefield = Array(4).fill().map(() => Array(4).fill());
-        updatedMinefield.forEach((row, rIndex) => {
-            row.forEach((cell, cIndex) => {
-                const adjCells = adjacentCells({row: rIndex, col: cIndex}, mineField)
-                let thisCell = {...mineField[rIndex][cIndex]}
-                thisCell.adjacentCells = adjCells
-                updatedMinefield[thisCell.row][thisCell.col] = {...thisCell}
-                expectedMinefield[thisCell.row][thisCell.col] = {...thisCell}
-            })
-        })
+        let updatedMinefield = mineField.copyMinefield()
+        let expectedMinefield = mineField.copyMinefield()
         let selectedCell = updatedMinefield[0][0]
-        const actualMinefield = cellClearer(selectedCell, [...updatedMinefield])
         expectedMinefield.forEach((row) => row.forEach((cell) => {
             cell.isCleared = !cell.hasMine
             cell.isFlagged = cell.hasMine
             return cell
         }))
+        const actualMinefield = cellClearer(selectedCell, [...updatedMinefield])
         expect(actualMinefield).toEqual(expectedMinefield)
     })
 })


### PR DESCRIPTION
I should have been doing pull requests initially, but I guess I might as well start here.

This update ensures that you can't click on a mine when starting a new game.  When the mine locations are randomly generated, the clicked cell and its adjacent cell can't be armed with a mine.